### PR TITLE
Migrate web chat redirection link to Libera Chat

### DIFF
--- a/webchat.html
+++ b/webchat.html
@@ -10,7 +10,7 @@
 
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<meta name="description" content="學生計算機年會 Web IRC | Students' Information Technology Conference Web IRC" />
-	<meta name="keywords" content="SITCON, Conference, Information, Information Technology, 學生計算機年會, 計算機年會, 年會, 研討會, SITCON, IRC, freenode" />
+	<meta name="keywords" content="SITCON, Conference, Information, Information Technology, 學生計算機年會, 計算機年會, 年會, 研討會, SITCON, IRC, freenode, libera chat" />
 
   <meta property="og:title" content="學生計算機年會 Web IRC"/>
   <meta property="og:type" content="website"/>
@@ -37,7 +37,7 @@
 </head>
 <body>
 
-  Your browser may not enable javascript, please click this <a href="https://webchat.freenode.net/?channels=sitcon" title="IRC">link</a> to open irc channel.
+  Your browser may not have JavaScript enabled. Please click this <a href="https://web.libera.chat/#SITCON" title="IRC">link</a> to connect to the IRC channel.
 
   <!-- Google Analytics -->
 	<script type="text/javascript">

--- a/webchat.html
+++ b/webchat.html
@@ -32,7 +32,7 @@
 	<!-- jQuery -->
 	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
   <script>
-    window.location = "https://webchat.freenode.net/?channels=sitcon";
+    window.location = "https://web.libera.chat/#SITCON";
   </script>
 </head>
 <body>


### PR DESCRIPTION
As freenode is in its demise, we need to start redirecting folks to the Libera Chat channel we’ve already created.

This patch does the trick.