### PR TITLE
Add Mastodon identity verification link to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,9 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    <!-- Mastodon link verification -->
+    <link href="https://g0v.social/@sitcontw" rel="me">
+
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
     <!-- Google Tag Manager -->


### PR DESCRIPTION
This is a follow-up of sitcon-tw/2023#37.  Since Mastodon does not follow JavaScript redirects (`window.location = ...`), currently we work around identity verification by linking to https://sitcon.org/2023/ instead of https://sitcon.org/ on the profile of [@sitcontw@g0v.social ](https://g0v.social/@sitcontw).

This PR adds a link with the `rel="me"` attribute so that we can link to https://sitcon.org/ while still getting verified.